### PR TITLE
Configurable Nack behaviour

### DIFF
--- a/async/subscriber.go
+++ b/async/subscriber.go
@@ -167,7 +167,7 @@ recvLoop:
 				opts.Logger.Error(fmt.Sprintf("[SERVICE: AsyncAgent][AMQP][%s] Nack: %s", cfg.Name, err))
 				shouldExit.Store(true)
 			} else if consumrCfg.NackDiscard {
-				opts.Logger.Warning(fmt.Sprintf("[SERVICE: AsyncAgent][AMQP][%s] Nack: message discarded from queue %q", cfg.Name, options.Name))
+				opts.Logger.Debug(fmt.Sprintf("[SERVICE: AsyncAgent][AMQP][%s] Nack: message discarded from queue %q", cfg.Name, options.Name))
 			}
 		}()
 	}

--- a/consumer.go
+++ b/consumer.go
@@ -85,7 +85,7 @@ func (f backendFactory) initConsumer(ctx context.Context, remote *config.Backend
 			if err != nil && err != io.EOF {
 				msg.Nack(false, !cfg.NackDiscard)
 				if cfg.NackDiscard {
-					f.logger.Warning(logPrefix, "Nack: message discarded from queue '"+cfg.Name+"'")
+					f.logger.Debug(logPrefix, "Nack: message discarded from queue '"+cfg.Name+"'")
 				}
 				return nil, err
 			}


### PR DESCRIPTION
Added a new `nack_discard` flag in AMQP driver config to customize the NACK behavior. The default is `false`, which requeues the message (this is backward compatible), otherwise, it discards the message

This flag can be added to async agents (`async/amqp`) and AMQP consumer backend (`backend/amqp/consumer`)